### PR TITLE
Add parameter for vendor specific elements into Beacon & Probe Response

### DIFF
--- a/hostapd/config_file.c
+++ b/hostapd/config_file.c
@@ -2035,6 +2035,39 @@ struct hostapd_config * hostapd_config_read(const char *fname)
 			else
 				bss->p2p &= ~P2P_ALLOW_CROSS_CONNECTION;
 #endif /* CONFIG_P2P_MANAGER */
+		} else if (os_strcmp(buf, "vendor_elements") == 0) {
+			struct wpabuf *elems;
+			size_t len = os_strlen(pos);
+			if (len & 0x01) {
+				wpa_printf(MSG_ERROR,
+					   "Line %d: Invalid vendor_elements '%s'",
+					   line, pos);
+				errors++;
+				continue;
+			}
+			len /= 2;
+			if (len == 0) {
+				wpabuf_free(bss->vendor_elements);
+				bss->vendor_elements = NULL;
+				continue;
+			}
+
+			elems = wpabuf_alloc(len);
+			if (elems == NULL)
+				errors++;
+				continue;
+
+			if (hexstr2bin(pos, wpabuf_put(elems, len), len)) {
+				wpabuf_free(elems);
+				wpa_printf(MSG_ERROR,
+					   "Line %d: Invalid vendor_elements '%s'",
+					   line, pos);
+				errors++;
+				continue;
+			}
+
+			wpabuf_free(bss->vendor_elements);
+			bss->vendor_elements = elems;
 		} else if (os_strcmp(buf, "disassoc_low_ack") == 0) {
 			bss->disassoc_low_ack = atoi(pos);
 		} else if (os_strcmp(buf, "tdls_prohibit") == 0) {

--- a/src/ap/ap_config.c
+++ b/src/ap/ap_config.c
@@ -467,6 +467,8 @@ static void hostapd_config_free_bss(struct hostapd_bss_config *conf)
 	os_free(conf->model_url);
 	os_free(conf->upc);
 #endif /* CONFIG_WPS */
+
+	wpabuf_free(conf->vendor_elements);
 }
 
 

--- a/src/ap/ap_config.h
+++ b/src/ap/ap_config.h
@@ -332,6 +332,8 @@ struct hostapd_bss_config {
 #define TDLS_PROHIBIT_CHAN_SWITCH BIT(1)
 	int tdls;
 	int disable_11n;
+
+	struct wpabuf *vendor_elements;
 };
 
 

--- a/src/ap/ap_drv_ops.c
+++ b/src/ap/ap_drv_ops.c
@@ -144,6 +144,15 @@ int hostapd_set_ap_wps_ie(struct hostapd_data *hapd)
 	}
 #endif /* CONFIG_P2P_MANAGER */
 
+	if (hapd->conf->vendor_elements) {
+		size_t add = wpabuf_len(hapd->conf->vendor_elements);
+		if (wpabuf_resize(&beacon, add) == 0)
+			wpabuf_put_buf(beacon, hapd->conf->vendor_elements);
+		if (wpabuf_resize(&proberesp, add) == 0)
+			wpabuf_put_buf(proberesp, hapd->conf->vendor_elements);
+	}
+
+
 	ret = hapd->driver->set_ap_wps_ie(hapd->drv_priv, beacon, proberesp,
 					  assocresp);
 

--- a/src/ap/beacon.c
+++ b/src/ap/beacon.c
@@ -307,6 +307,8 @@ void handle_probe_req(struct hostapd_data *hapd,
 	if (hapd->p2p_probe_resp_ie)
 		buflen += wpabuf_len(hapd->p2p_probe_resp_ie);
 #endif /* CONFIG_P2P */
+	if (hapd->conf->vendor_elements)
+		buflen += wpabuf_len(hapd->conf->vendor_elements);
 	resp = os_zalloc(buflen);
 	if (resp == NULL)
 		return;
@@ -380,6 +382,12 @@ void handle_probe_req(struct hostapd_data *hapd,
 		pos = hostapd_eid_p2p_manage(hapd, pos);
 #endif /* CONFIG_P2P_MANAGER */
 
+	if (hapd->conf->vendor_elements) {
+		os_memcpy(pos, wpabuf_head(hapd->conf->vendor_elements),
+			  wpabuf_len(hapd->conf->vendor_elements));
+		pos += wpabuf_len(hapd->conf->vendor_elements);
+	}
+
 	if (hostapd_drv_send_mlme(hapd, resp, pos - (u8 *) resp) < 0)
 		perror("handle_probe_req: send");
 
@@ -415,6 +423,8 @@ void ieee802_11_set_beacon(struct hostapd_data *hapd)
 	if (hapd->p2p_beacon_ie)
 		tail_len += wpabuf_len(hapd->p2p_beacon_ie);
 #endif /* CONFIG_P2P */
+	if (hapd->conf->vendor_elements)
+		tail_len += wpabuf_len(hapd->conf->vendor_elements);
 	tailpos = tail = os_malloc(tail_len);
 	if (head == NULL || tail == NULL) {
 		wpa_printf(MSG_ERROR, "Failed to set beacon data");
@@ -510,6 +520,12 @@ void ieee802_11_set_beacon(struct hostapd_data *hapd)
 	    P2P_MANAGE)
 		tailpos = hostapd_eid_p2p_manage(hapd, tailpos);
 #endif /* CONFIG_P2P_MANAGER */
+
+	if (hapd->conf->vendor_elements) {
+		os_memcpy(tailpos, wpabuf_head(hapd->conf->vendor_elements),
+			  wpabuf_len(hapd->conf->vendor_elements));
+		tailpos += wpabuf_len(hapd->conf->vendor_elements);
+	}
 
 	tail_len = tailpos > tail ? tailpos - tail : 0;
 


### PR DESCRIPTION
This PR is a patch for "vendor_elements" parameter enabling in hostapd.conf.

hostapd 2.5(https://w1.fi/hostapd/) already supports vendor_elements parameter, but RTL8188-hostapd doesn't.
This patch is working for me(Raspberry Pi 2 + Raspbian jessie + hostapd).

Plz check my PR.
